### PR TITLE
feat: add support for mux-data

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -7,6 +7,7 @@ declare module '*?url' {
   const S: string
   export = S
 }
+
 declare module '*?raw' {
   const S: string
   export = S
@@ -16,4 +17,19 @@ declare module 'hls.js/dist/hls.light.min.js' {
   import type Hls from 'hls.js'
 
   export = Hls
+}
+
+declare module 'mux-embed' {
+  type M = {
+    monitor: (element: HTMLElement | string, props: Record<string, any>) => void,
+    utils: any
+  }
+
+  export = M
+}
+
+declare module '@mux/mux-data-chromecast' {
+  function M (player: any, props: Record<string, any>): void
+
+  export = M
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -27,9 +27,3 @@ declare module 'mux-embed' {
 
   export = M
 }
-
-declare module '@mux/mux-data-chromecast' {
-  function M (player: any, props: Record<string, any>): void
-
-  export = M
-}

--- a/package.json
+++ b/package.json
@@ -62,21 +62,20 @@
     "storybook": "^7.0.0-beta.49",
     "typescript-json-schema": "^0.55.0",
     "vite": "^4.3.9",
-    "web-component-analyzer": "2.0.0-next.4"
+    "web-component-analyzer": "2.0.0-next.4",
+    "@types/chromecast-caf-sender": "^1.0.5"
   },
   "optionalDependencies": {
     "lit": "^2.7.5",
     "lit-html": "^2.7.4",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "hls.js": "^1.3.3",
+    "mux-embed": "^4.26.0"
   },
   "dependencies": {
     "@lit-labs/context": "^0.2.0",
     "@lit/reactive-element": "^1.6.1",
-    "@mux/mux-data-chromecast": "^4.11.5",
     "@popperjs/core": "^2.11.6",
-    "@types/chromecast-caf-sender": "^1.0.5",
-    "debug": "^4.3.4",
-    "hls.js": "^1.3.3",
-    "mux-embed": "^4.26.0"
+    "debug": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,9 +72,11 @@
   "dependencies": {
     "@lit-labs/context": "^0.2.0",
     "@lit/reactive-element": "^1.6.1",
+    "@mux/mux-data-chromecast": "^4.11.5",
     "@popperjs/core": "^2.11.6",
     "@types/chromecast-caf-sender": "^1.0.5",
     "debug": "^4.3.4",
-    "hls.js": "^1.3.3"
+    "hls.js": "^1.3.3",
+    "mux-embed": "^4.26.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@lit/reactive-element':
     specifier: ^1.6.1
     version: 1.6.1
+  '@mux/mux-data-chromecast':
+    specifier: ^4.11.5
+    version: 4.11.5
   '@popperjs/core':
     specifier: ^2.11.6
     version: 2.11.6
@@ -23,6 +26,9 @@ dependencies:
   hls.js:
     specifier: ^1.3.3
     version: 1.3.3
+  mux-embed:
+    specifier: ^4.26.0
+    version: 4.26.0
 
 optionalDependencies:
   lit:
@@ -2221,6 +2227,12 @@ packages:
       '@types/react': 18.0.26
       react: 18.2.0
     dev: true
+
+  /@mux/mux-data-chromecast@4.11.5:
+    resolution: {integrity: sha512-0zYf3HCA3Vou0bhjxQ6+aSRk1R8RA5q48SXCbNc51ioYSShQ7vmKc+IZ/xUVdPsJUdMsZmunQaPs6OhruDcZRA==}
+    dependencies:
+      mux-embed: 4.26.0
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5929,6 +5941,10 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
+
+  /mux-embed@4.26.0:
+    resolution: {integrity: sha512-SvQahoUAe/WL+c4zyTb7dnO381x/MwlSfFHKirco/FyZAPirD8WnF/Ry+GxTQzucJFY2CMw8PsmPgy/ckkC2ZQ==}
+    dev: false
 
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,32 +11,26 @@ dependencies:
   '@lit/reactive-element':
     specifier: ^1.6.1
     version: 1.6.1
-  '@mux/mux-data-chromecast':
-    specifier: ^4.11.5
-    version: 4.11.5
   '@popperjs/core':
     specifier: ^2.11.6
     version: 2.11.6
-  '@types/chromecast-caf-sender':
-    specifier: ^1.0.5
-    version: 1.0.5
   debug:
     specifier: ^4.3.4
     version: 4.3.4
+
+optionalDependencies:
   hls.js:
     specifier: ^1.3.3
     version: 1.3.3
-  mux-embed:
-    specifier: ^4.26.0
-    version: 4.26.0
-
-optionalDependencies:
   lit:
     specifier: ^2.7.5
     version: 2.7.5
   lit-html:
     specifier: ^2.7.4
     version: 2.7.4
+  mux-embed:
+    specifier: ^4.26.0
+    version: 4.26.0
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
@@ -63,6 +57,9 @@ devDependencies:
   '@storybook/web-components-vite':
     specifier: ^7.0.0-beta.49
     version: 7.0.0-beta.49(lit@2.7.5)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.3.9)
+  '@types/chromecast-caf-sender':
+    specifier: ^1.0.5
+    version: 1.0.5
   '@types/debug':
     specifier: ^4.1.7
     version: 4.1.7
@@ -2228,12 +2225,6 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@mux/mux-data-chromecast@4.11.5:
-    resolution: {integrity: sha512-0zYf3HCA3Vou0bhjxQ6+aSRk1R8RA5q48SXCbNc51ioYSShQ7vmKc+IZ/xUVdPsJUdMsZmunQaPs6OhruDcZRA==}
-    dependencies:
-      mux-embed: 4.26.0
-    dev: false
-
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3147,13 +3138,13 @@ packages:
     dependencies:
       '@types/filesystem': 0.0.32
       '@types/har-format': 1.2.11
-    dev: false
+    dev: true
 
   /@types/chromecast-caf-sender@1.0.5:
     resolution: {integrity: sha512-8d6RRCOYYiKzDyFJKAYKOp7Eo0kUfj9imnLQj0uuh/QGSz8euL9OOeKmh8XizqTcKW5tXva6li0mRYtnvzVIcA==}
     dependencies:
       '@types/chrome': 0.0.237
-    dev: false
+    dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
@@ -3200,11 +3191,11 @@ packages:
     resolution: {integrity: sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==}
     dependencies:
       '@types/filewriter': 0.0.29
-    dev: false
+    dev: true
 
   /@types/filewriter@0.0.29:
     resolution: {integrity: sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==}
-    dev: false
+    dev: true
 
   /@types/find-cache-dir@3.2.1:
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
@@ -3225,7 +3216,7 @@ packages:
 
   /@types/har-format@1.2.11:
     resolution: {integrity: sha512-T232/TneofqK30AD1LRrrf8KnjLvzrjWDp7eWST5KoiSzrBfRsLrWDPk4STQPW4NZG6v2MltnduBVmakbZOBIQ==}
-    dev: false
+    dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
@@ -5127,7 +5118,9 @@ packages:
 
   /hls.js@1.3.3:
     resolution: {integrity: sha512-4Efu6g90HfFGDuQrkquhDoRpA/4iVpSMcfK9zguJ2qXEUfo5VknZt6rziwwFPHmC2DU3crZ0NtPD0eUqOhFyqg==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -5944,7 +5937,9 @@ packages:
 
   /mux-embed@4.26.0:
     resolution: {integrity: sha512-SvQahoUAe/WL+c4zyTb7dnO381x/MwlSfFHKirco/FyZAPirD8WnF/Ry+GxTQzucJFY2CMw8PsmPgy/ckkC2ZQ==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}

--- a/src/components/video-chromecast/Video-chromecast.component.ts
+++ b/src/components/video-chromecast/Video-chromecast.component.ts
@@ -184,7 +184,7 @@ export class VideoChromecast extends LitElement {
     Object
       .values(cast.framework.RemotePlayerEventType)
       .forEach(event => this.controller.addEventListener(event, this.handleCastEvent))
-    
+  
     dispatch(this, Action.castAvailable)
   }
 

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -5,6 +5,8 @@ import styles from './Video-container.styles.css?inline'
 import type Hls from 'hls.js'
 import { getCueText } from '../../helpers/cue'
 import { getBufferedEnd } from '../../helpers/buffer'
+import { connectMuxData } from '../../helpers/mux'
+import { MuxParams } from '../../types'
 
 /**
  * @slot - Video-container main content
@@ -15,12 +17,16 @@ export class VideoContainer extends LitElement {
   public command = createCommand(this)
 
   hls: Hls
+  initTime: number
 
   @queryAssignedElements({ selector: 'video', flatten: true })
   videos: HTMLVideoElement[]
 
   @connect('activeTextTrack')
   activeTextTrack: string
+
+  @connect('muxData')
+  muxData: MuxParams
 
   @connect('castActivated')
   castActivated: string
@@ -142,6 +148,15 @@ export class VideoContainer extends LitElement {
     }
   }
 
+  @listen(Types.Command.init, { isSourceSupported: true })
+  initNative() {
+    console.log('here')
+    if (this.muxData) connectMuxData(
+      this.videos[0],
+      { ...this.muxData, player_init_time: this.initTime }
+    )
+  }
+
   @listen(Types.Command.initCustomHLS)
   @listen(Types.Command.init, { isSourceSupported: false })
   async initHls() {
@@ -160,6 +175,12 @@ export class VideoContainer extends LitElement {
       levelLoadingMaxRetry: 4,
       backBufferLength: navigator.userAgent.match(/Android/i) ? 0 : 30
     })
+    
+    if (this.muxData) await connectMuxData(
+      this.videos[0],
+      { ...this.muxData, player_init_time: this.initTime },
+      { Hls: HLS, hlsjs: this.hls }
+    )
 
     this.hls.on(HLS.Events.LEVEL_UPDATED, (_: unknown, { level }: { level: number }) => {
       dispatch(this, Types.Action.setQualityLevel, {
@@ -261,6 +282,8 @@ export class VideoContainer extends LitElement {
       volume, duration, currentTime,
       playbackRate, title
     }] = this.videos
+
+    this.initTime = Date.now()
 
     // Show native controls on safari browser
     if (this.mobileSafari) this.videos[0].setAttribute('controls', 'true')

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -150,7 +150,6 @@ export class VideoContainer extends LitElement {
 
   @listen(Types.Command.init, { isSourceSupported: true })
   initNative() {
-    console.log('here')
     if (this.muxData) connectMuxData(
       this.videos[0],
       { ...this.muxData, player_init_time: this.initTime }

--- a/src/components/video-live-sign/Video-live-sign.component.ts
+++ b/src/components/video-live-sign/Video-live-sign.component.ts
@@ -1,6 +1,5 @@
 import { unsafeCSS, LitElement, html } from 'lit'
-import { classMap } from 'lit/directives/class-map.js'
-import { customElement, property, state } from 'lit/decorators.js'
+import { customElement } from 'lit/decorators.js'
 import styles from './Video-live-sign.styles.css?inline'
 
 @customElement('video-live-sign')

--- a/src/components/video-player/Video-player.component.ts
+++ b/src/components/video-player/Video-player.component.ts
@@ -9,6 +9,7 @@ import { FullscreenController } from './controllers/Fullscreen'
 import { IdleController } from './controllers/Idle'
 import { KeyboardController } from './controllers/Keyboard'
 import { emit } from '../../helpers/event'
+import { Action, MuxParams } from '../../types'
 
 @customElement('video-player')
 export class VideoPlayer extends LitElement {
@@ -25,6 +26,9 @@ export class VideoPlayer extends LitElement {
 
   @property({ type: Boolean, reflect: true })
   idle = false
+
+  @property({ type: Object, attribute: 'mux-data' })
+  muxData: MuxParams
 
   @property({ type: Boolean })
   autofocus = false
@@ -74,6 +78,10 @@ export class VideoPlayer extends LitElement {
     this.addEventListener('touchstart', this.handleMove, { passive: true })
     this.addEventListener('mousemove', this.handleMove)
     this.addEventListener('mouseleave', this.handleMove)
+
+    if (this.muxData?.env_key) {
+      this.state.setState(Action.setMuxParams, { muxData: this.muxData })
+    }
   }
 
   disconnectedCallback(): void {

--- a/src/components/video-slider/Video-slider.component.ts
+++ b/src/components/video-slider/Video-slider.component.ts
@@ -165,8 +165,8 @@ export class VideoSlider extends LitElement {
           step="0.001"
           role="slider"
           ?disabled=${this.disabled}
-          .value=${this.positionInPercents || '0'}
-          .aria-valuenow=${this.currentValue || '0'}
+          .value=${this.positionInPercents}
+          .aria-valuenow=${this.currentValue}
           aria-valuemin="0"
           aria-valuemax="1"
           autocomplete="off"

--- a/src/components/video-slider/Video-slider.component.ts
+++ b/src/components/video-slider/Video-slider.component.ts
@@ -165,8 +165,8 @@ export class VideoSlider extends LitElement {
           step="0.001"
           role="slider"
           ?disabled=${this.disabled}
-          .value=${this.positionInPercents}
-          .aria-valuenow=${this.currentValue}
+          .value=${this.positionInPercents || '0'}
+          .aria-valuenow=${this.currentValue || '0'}
           aria-valuemin="0"
           aria-valuemax="1"
           autocomplete="off"

--- a/src/helpers/mux.ts
+++ b/src/helpers/mux.ts
@@ -1,0 +1,16 @@
+import { MuxOptions, MuxParams } from '../types'
+
+export const connectMuxData = async (
+  element: HTMLElement,
+  data: MuxParams,
+  options?: MuxOptions
+) => {
+  const mux = await import('mux-embed')
+  mux.monitor(element, {
+    ...options,
+    data: {
+      ...data,
+      player_version: options?.Hls ? 'HLS' : 'Native'
+    }
+  })
+}

--- a/src/state/controller.ts
+++ b/src/state/controller.ts
@@ -88,15 +88,20 @@ export class StateController extends ContextProvider<Context> {
     this.host.removeEventListener(Event.registerCommand, this.registerCommand)
   }
 
-  handleEvent = (e: CustomEvent<StateAction>) => {
-    e.stopPropagation()
+  setState = (action: Action, params: Record<string, any>) => {
     const prevState = this.value
-    this.setValue(mapState(e.detail.action, this.value, e.detail.params))
+    this.setValue(mapState(action, this.value, params))
     if (prevState !== this.value) {
       Promise.resolve().then(() => {
-        stateDebug(`[${Action[e.detail.action]}]`, e.detail.params)
+        stateDebug(`[${Action[action]}]`, params)
       })
     }
+  }
+
+  handleEvent = (e: CustomEvent<StateAction>) => {
+    e.stopPropagation()
+    this.setState(e.detail.action, e.detail.params)
+
     Promise.resolve().then(() => this.resolvePendingCommands())
   }
 

--- a/src/state/mapper.ts
+++ b/src/state/mapper.ts
@@ -2,7 +2,8 @@ import { initialState } from '.'
 import { Action, State } from '../types'
 
 export const stateMapper: Partial<Record<Action, (s: State, v: any) => State>> = {
-  [Action.init]: (_, params) => ({
+  [Action.init]: (s, params) => ({
+    ...s,
     ...initialState,
     ...params
   }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { device } from "./helpers/device"
+import type Hls from 'hls.js'
 
 /**
  * Command are the actions that can be triggered by the user or a interface
@@ -74,6 +75,7 @@ export enum Action {
   castAvailable,
   setCastStatus,
   setBuffer,
+  setMuxParams
 }
 
 export enum Event {
@@ -117,5 +119,31 @@ export type State = Partial<{
   }[],
   qualityLevels: {
     name: string
-  }[]
+  }[],
+  muxData: MuxParams
 } & typeof device>
+
+export type MuxParams = {
+  env_key: string
+  
+  /** any arbitrary string you want to use to identify this player */
+  player_name?: string
+  player_init_time?: number
+  player_version?: string
+
+  viewer_user_id?: string
+  experiment_name?: string
+
+  video_id?: string
+  video_title?: string
+  video_series?: string
+  video_duration?: string
+  video_stream_type?: string
+  video_cdn?: string
+}
+
+export type MuxOptions = {
+  debug?: boolean
+  Hls?: (typeof import('hls.js'))['default']
+  hlsjs?: Hls
+}


### PR DESCRIPTION
### Description
This PR provides an opportunity to track video errors and health by using `mux-data`
To make it track analytics, you have to provide at least `env_key` variable
```html
<video-player mux-data='{"env_key": "your key"}'>
...
</video-player>
```

closes: https://github.com/Uscreen-video/uscreen_2/issues/12271