### PR TITLE
feat: save settings in local storage

### DIFF
--- a/src/Playgroud.stories.mdx
+++ b/src/Playgroud.stories.mdx
@@ -23,7 +23,7 @@ import './components/buttons/Pip'
 <Meta title="Playground" />
 
 <Canvas>
-  <video-player>
+  <video-player storage-key="uscreen:player">
     <video
       slot="video"
       title="My test video"

--- a/src/components/video-button/Video-button.component.ts
+++ b/src/components/video-button/Video-button.component.ts
@@ -68,6 +68,7 @@ export class VideoButton extends LitElement {
   destroyMenu(): void {
     this.menuPopper?.destroy()
     this.menuPopper = undefined
+    this.destroyTooltip()
   }
 
   protected firstUpdated(): void {

--- a/src/components/video-chromecast/Video-chromecast.component.ts
+++ b/src/components/video-chromecast/Video-chromecast.component.ts
@@ -65,7 +65,7 @@ export class VideoChromecast extends LitElement {
   @listen(Command.toggleMuted, { castActivated: true })
   @listen(Command.mute)
   mute() {
-    this.controller.muteOrUnmute()
+    if (this.controller) this.controller.muteOrUnmute()
   }
 
   @listen(Command.setVolume, { castActivated: true })

--- a/src/components/video-chromecast/Video-chromecast.component.ts
+++ b/src/components/video-chromecast/Video-chromecast.component.ts
@@ -65,7 +65,7 @@ export class VideoChromecast extends LitElement {
   @listen(Command.toggleMuted, { castActivated: true })
   @listen(Command.mute)
   mute() {
-    if (this.controller) this.controller.muteOrUnmute()
+    this.controller?.muteOrUnmute()
   }
 
   @listen(Command.setVolume, { castActivated: true })

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -395,6 +395,7 @@ export class VideoContainer extends LitElement {
       volume,
       title,
       playbackRate,
+      sources: this.videoSources,
       src: this.videoSource,
       isAutoplay: autoplay,
       isMuted: muted,
@@ -444,8 +445,11 @@ export class VideoContainer extends LitElement {
     `
   }
 
-  get videoSources() {
-    return Array.from(this.videos[0].querySelectorAll('source'))
+  get videoSources(): State['sources'] {
+    return Array.from(this.videos[0].querySelectorAll('source')).map(s => ({
+      type: s.type,
+      src: s.src
+    }))
   }
 
   get videoTracks() {

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -51,9 +51,7 @@ export class VideoContainer extends LitElement {
   _storageProvider: StorageProvider
   connectedCallback() {
     super.connectedCallback();
-    if (this.storageKey) {
-      this._storageProvider = createProvider(this.storageKey)
-    }
+    this._storageProvider = createProvider(this.storageKey)
   }
 
   @listen(Types.Command.play, { canPlay: true, castActivated: false })
@@ -226,7 +224,7 @@ export class VideoContainer extends LitElement {
           name: level.height || 'auto'
         }))
       })
-      const { activeQualityLevel } = this._storageProvider ? this._storageProvider.get() : {} as StorageValue
+      const { activeQualityLevel } = this._storageProvider.get()
       if (activeQualityLevel >= 0) {
         const qualityLevelIdx = levels.findIndex(({ height }) => height === activeQualityLevel)
         if (qualityLevelIdx >= 0) {
@@ -331,7 +329,7 @@ export class VideoContainer extends LitElement {
   @listen(Types.Command.setPlaybackRate)
   @listen(Types.Command.enableTextTrack)
   _syncStateWithStorage(params: CommandParams, _: any, command: Types.Command) {
-    if (!this._storageProvider) return
+    if (!this.storageKey) return
 
     let key: keyof State
     let value: unknown
@@ -366,7 +364,7 @@ export class VideoContainer extends LitElement {
 
   setup() {
     // active quality level will be initialized in HLS callback
-    const { activeQualityLevel, ...savedSettings } = this._storageProvider ? this._storageProvider.get() : {} as StorageValue
+    const { activeQualityLevel, ...savedSettings } = this._storageProvider.get()
     
     if (typeof savedSettings.isMuted === 'boolean') {
       this.videos[0].muted = savedSettings.isMuted

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -166,11 +166,10 @@ export class VideoContainer extends LitElement {
   setHLSQualityLevel({ level }: { level: number }) {
     const qualityLevelIdx = this.hls.levels.findIndex(({ height }) => height === level)
     this.hls.nextLevel = qualityLevelIdx
-    if (qualityLevelIdx === -1) {
-      dispatch(this, Types.Action.setQualityLevel, {
-        activeQualityLevel: -1
-      })
-    }
+    // We need to update state here as well, as HLS.Events.LEVEL_UPDATED sometimes not triggered
+    dispatch(this, Types.Action.setQualityLevel, {
+      activeQualityLevel: qualityLevelIdx === -1 ? -1 : level
+    })
   }
 
   @listen(Types.Command.togglePip)

--- a/src/components/video-player/Video-player.component.ts
+++ b/src/components/video-player/Video-player.component.ts
@@ -40,6 +40,9 @@ export class VideoPlayer extends LitElement {
   @property({ type: Number, attribute: true, reflect: true })
   tabindex = 0
 
+  @property({ type: String, attribute: 'storage-key' })
+  storageKey: string
+
   @listen(Types.Command.toggleFullscreen)
   toggleFullscreen = () => {
     if (this.state.value.isFullscreen) {
@@ -95,7 +98,7 @@ export class VideoPlayer extends LitElement {
 
   render() {
     return html`
-      <video-container>
+      <video-container storage-key=${this.storageKey}>
         <slot name="video"></slot>
         <slot name="chromecast">
           <video-chromecast></video-chromecast>

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -15,16 +15,19 @@ export type StorageProvider = {
   clear: () => void
 }
 
-export const createProvider = (key: string): StorageProvider => {
+export const createProvider = (key?: string): StorageProvider => {
   const Provider: StorageProvider = {
     get: () => {
+      if (!key) return {}
       const item = window.localStorage.getItem(key)
       return item ? JSON.parse(item) : {} 
     },
     set: (val) => {
+      if (!key) return
       window.localStorage.setItem(key, JSON.stringify(val))
     },
     clear: () => {
+      if (!key) return
       window.localStorage.removeItem(key)
     }
   }

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -1,0 +1,33 @@
+import { State } from '../types'
+
+
+export type StorageValue = Partial<Pick<State,
+  'isMuted' | 
+  'volume' |
+  'activeQualityLevel' |
+  'activeTextTrack' |
+  'playbackRate'
+>>
+
+export type StorageProvider = {
+  get: () => StorageValue,
+  set: (val: StorageValue) => void,
+  clear: () => void
+}
+
+export const createProvider = (key: string): StorageProvider => {
+  const Provider: StorageProvider = {
+    get: () => {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : {} 
+    },
+    set: (val) => {
+      window.localStorage.setItem(key, JSON.stringify(val))
+    },
+    clear: () => {
+      window.localStorage.removeItem(key)
+    }
+  }
+
+  return Provider
+}

--- a/src/state/commander.ts
+++ b/src/state/commander.ts
@@ -25,7 +25,7 @@ export class EventListener implements ReactiveController {
       this.command,
       this.dependencies,
       (params, meta, unsubscribe, resolve, reject) => {
-        const fx = (this.host as any)[this.name](params, meta)
+        const fx = (this.host as any)[this.name](params, meta, this.command)
         this.unsubscribe = unsubscribe
         debugCommand(`[${Command[this.command]}] handled`, params)
         if (fx instanceof Promise) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,10 @@ export type State = Partial<{
   duration: number,
   currentTime: number,
   src: string,
+  sources: {
+    type: string,
+    src: string
+  }[],
   title: string,
   poster: string,
   volume: number,


### PR DESCRIPTION
- Added ability to save settings in local storage.
Added optional prop: `storage-key` to top level player component - if provided player will be initialized with saved settings and will save selected user settings to the local storage using provided key
- Fix selected quality level sync (correctly display selected quality leve)
- Destroy button tooltip on menu destroy to prevent issues when menu is destroyed but tooltip still visible
- Save list of available sources in state

Closes https://github.com/Uscreen-video/video-player/issues/12
Closes https://github.com/Uscreen-video/video-player/issues/20