### PR TITLE
fix: render chromecast component on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uscreen-video-player",
-  "version": "0.1.115",
+  "version": "0.1.117",
   "type": "module",
   "description": "Video player as customizable web-component",
   "main": "./dist/index.js",

--- a/src/Playgroud.stories.mdx
+++ b/src/Playgroud.stories.mdx
@@ -3,6 +3,7 @@ import { Meta, Canvas } from '@storybook/blocks'
 import enCaptions from '../mocks/captions_en.vtt?url'
 
 import './components/video-player'
+import './components/video-chromecast'
 import './components/video-controls'
 import './components/video-timeline'
 import './components/video-timer'
@@ -42,6 +43,7 @@ import './components/Video-condition'
         src={enCaptions}
       />
     </video>
+    <video-chromecast slot="chromecast"></video-chromecast>
     <video-condition query="canPlay == true && played != true">
       <video-play-button
         without-tooltip

--- a/src/components/video-chromecast/Video-chromecast.component.ts
+++ b/src/components/video-chromecast/Video-chromecast.component.ts
@@ -185,7 +185,7 @@ export class VideoChromecast extends LitElement {
       .values(cast.framework.RemotePlayerEventType)
       .forEach(event => this.controller.addEventListener(event, this.handleCastEvent))
   
-    dispatch(this, Action.castAvailable)
+    dispatch(this, Action.setCastStatus, { castAvailable: true })
   }
 
   loadChromeCastFramework() {
@@ -199,8 +199,11 @@ export class VideoChromecast extends LitElement {
     if (window.chrome?.cast?.isAvailable) {
       this.initChromeCast()
     } else {
-      if (tries++ > 20) dispatch(this, Action.setCastStatus, { castAvailable: false })
-      else setTimeout(this.handleChromeCastLoad, 250, tries)
+      if (tries++ > 20) {
+        dispatch(this, Action.setCastStatus, { castAvailable: false })
+      } else {
+        setTimeout(this.handleChromeCastLoad, 250, tries)
+      }
     }
 
   }

--- a/src/components/video-chromecast/Video-chromecast.component.ts
+++ b/src/components/video-chromecast/Video-chromecast.component.ts
@@ -189,8 +189,12 @@ export class VideoChromecast extends LitElement {
   }
 
   loadChromeCastFramework() {
+    const existingScript = document.getElementById('uscreen-player-chromecast-framework')
+    if (existingScript) return
+
     const script = document.createElement('script')
     script.src = 'https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1'
+    script.id = 'uscreen-player-chromecast-framework'
     script.addEventListener('load', () => this.handleChromeCastLoad(0))
     document.head.appendChild(script)
   }

--- a/src/components/video-player/Video-player.component.ts
+++ b/src/components/video-player/Video-player.component.ts
@@ -114,9 +114,7 @@ export class VideoPlayer extends LitElement {
     return html`
       <video-container storage-key=${this.storageKey}>
         <slot name="video"></slot>
-        <slot name="chromecast">
-          <video-chromecast></video-chromecast>
-        </slot>
+        <slot name="chromecast"></slot>
         <slot name="errors">
           <video-errors-manager></video-errors-manager>
         </slot>

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -17,7 +17,6 @@ export const initialState: State = {
   cues: [],
   castActivated: false,
   played: false,
-  castAvailable: Boolean(window.chrome?.cast?.isAvailable),
   airplayAvailable: Boolean((window as any).WebKitPlaybackTargetAvailabilityEvent),
   pipAvailable: Boolean(document.pictureInPictureEnabled),
   ...device

--- a/src/state/mapper.ts
+++ b/src/state/mapper.ts
@@ -29,10 +29,6 @@ export const stateMapper: Partial<Record<Action, (s: State, v: any) => State>> =
     ...state,
     airplayActivated: !state.airplayActivated
   }),
-  [Action.castAvailable]: (state) => ({
-    ...state,
-    castAvailable: true
-  }),
   [Action.canPlay]: (state) => ({
     ...state,
     canPlay: true

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,6 @@ export enum Action {
   updateAirplayStatus = 'updateAirplayStatus',
   toggleAirplay = 'toggleAirplay',
   togglePip = 'togglePip',
-  castAvailable = 'castAvailable',
   setCastStatus = 'setCastStatus',
   setBuffer = 'setBuffer',
   setMuxParams = 'setMuxParams',


### PR DESCRIPTION
Render chromecast component on demand

Removed chromecast component from `video-player` component.

If client need chromecast - he can provide corresponded slot

Removed `castAvailable` action as we already have `setCastStatus` action to simplify code base

Avoid chromecast script duplication on the page