### PR TITLE
feat: added ability to lazy load player

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uscreen-video-player",
-  "version": "0.1.118-beta1",
+  "version": "0.1.118",
   "type": "module",
   "description": "Video player as customizable web-component",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uscreen-video-player",
-  "version": "0.1.117",
+  "version": "0.1.118-beta1",
   "type": "module",
   "description": "Video player as customizable web-component",
   "main": "./dist/index.js",

--- a/src/components/video-container/sources.ts
+++ b/src/components/video-container/sources.ts
@@ -1,0 +1,24 @@
+import { State } from '../../types'
+
+export const sourcesController = (video: HTMLVideoElement) => {
+  const sources = Array.from(video.querySelectorAll('source'))
+
+  const supportedSource = sources.find(s => video.canPlayType(s.type))
+
+  const activeSource = supportedSource || sources[0]
+
+  return {
+    allSources: (): State['sources'] => sources.map(s => ({
+      type: s.type,
+      src: s.src || s.getAttribute('data-src')
+    })),
+    isSourceSupported: () => !!supportedSource,
+    getSrc: () => activeSource.src || activeSource.getAttribute('data-src'),
+    enableSource: () => {
+      activeSource.src = activeSource.src || activeSource.getAttribute('data-src')
+    },
+    isLazy: () => !activeSource.src
+  }
+}
+
+export type SourcesController = ReturnType<typeof sourcesController>


### PR DESCRIPTION
Added ability to lazy load player

If instead of `src` attribute you'll provide `data-src` attribute to the `source` HTML element - player will not be initialized until client manually trigger `init` command