### PR TITLE
fix: disable subtitles by default

### DIFF
--- a/src/components/video-container/subtitles.ts
+++ b/src/components/video-container/subtitles.ts
@@ -77,6 +77,12 @@ export const subtitlesController = (
   hls: Hls,
   defaultTextTrack?: string
 ) => {
+  if (hls) {
+    // Disable subtitles by default
+    hls.subtitleTrack = -1
+    hls.subtitleDisplay = false
+  }
+
   let activeTextTrack = defaultTextTrack
 
   const tracksManager = videoTextTtracksManager(video, hls)


### PR DESCRIPTION
Disable subtitles by default.

Subtitles will be shown only after player initialization