### PR TITLE
feat: basic drm support

### DIFF
--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -269,14 +269,14 @@ export class VideoContainer extends LitElement {
       emeEnabled: !!this.drmOptions,
       drmSystems: this.drmOptions ? {
         'com.apple.fps': {
-          licenseUrl: this.drmOptions[KeySystems.fps].licenseUrl,
-          serverCertificateUrl: this.drmOptions[KeySystems.fps].certificateUrl,
+          licenseUrl: this.drmOptions[KeySystems.fps]?.licenseUrl,
+          serverCertificateUrl: this.drmOptions[KeySystems.fps]?.certificateUrl,
         },
         'com.widevine.alpha': {
-          licenseUrl: this.drmOptions[KeySystems.widevine].licenseUrl
+          licenseUrl: this.drmOptions[KeySystems.widevine]?.licenseUrl
         },
         'com.microsoft.playready': {
-          licenseUrl: this.drmOptions[KeySystems.playready].licenseUrl
+          licenseUrl: this.drmOptions[KeySystems.playready]?.licenseUrl
         }
       } : {}
     });

--- a/src/components/video-container/Video-container.component.ts
+++ b/src/components/video-container/Video-container.component.ts
@@ -273,10 +273,10 @@ export class VideoContainer extends LitElement {
           serverCertificateUrl: this.drmOptions[KeySystems.fps].certificateUrl,
         },
         'com.widevine.alpha': {
-          licenseUrl: this.drmOptions[KeySystems.widevine]
+          licenseUrl: this.drmOptions[KeySystems.widevine].licenseUrl
         },
         'com.microsoft.playready': {
-          licenseUrl: this.drmOptions[KeySystems.playready]
+          licenseUrl: this.drmOptions[KeySystems.playready].licenseUrl
         }
       } : {}
     });

--- a/src/components/video-player/Video-player.component.ts
+++ b/src/components/video-player/Video-player.component.ts
@@ -11,7 +11,7 @@ import { FullscreenController } from "./controllers/Fullscreen";
 import { IdleController } from "./controllers/Idle";
 import { KeyboardController } from "./controllers/Keyboard";
 import { emit } from "../../helpers/event";
-import { Action, MuxParams } from "../../types";
+import { Action, MuxParams, DRMOptions } from "../../types";
 import { watch } from "../../decorators/watch";
 import styles from "./Video-player.styles.css?inline";
 
@@ -79,6 +79,12 @@ export class VideoPlayer extends LitElement {
   @property({ type: Number })
   offset: number;
 
+  /**
+   * DRM options
+   */
+  @property({ type: Object, attribute: "drm-options" })
+  drmOptions?: DRMOptions
+
   @listen(Types.Command.toggleFullscreen)
   toggleFullscreen = () => {
     if (this.state.value.isFullscreen) {
@@ -129,6 +135,10 @@ export class VideoPlayer extends LitElement {
 
     if (this.muxData?.env_key) {
       this.state.setState(Action.setMuxParams, { muxData: this.muxData });
+    }
+
+    if (this.drmOptions) {
+      this.state.setState(Action.setDRMOptions, { drmOptions: this.drmOptions });
     }
   }
 

--- a/src/helpers/drm.ts
+++ b/src/helpers/drm.ts
@@ -16,8 +16,6 @@ const loadFairPlayCertificate = async (certificateUrl: string) => {
 
 const fairplayEncryptedCallback = (fairPlayCertificate: ArrayBuffer, licenseServerUrl: string) => {
   return async (event: MediaEncryptedEvent) => {
-    console.log("fairplayEncrypted callback", event);
-
     const video = event.target as HTMLVideoElement;
     const initDataType = event.initDataType;
 
@@ -49,14 +47,10 @@ const fairplayEncryptedCallback = (fairPlayCertificate: ArrayBuffer, licenseServ
 }
 
 const getLicenseResponse = async (event: MediaKeySessionEventMap["message"], licenseServerUrl: string) => {
-  // let spc_string = btoa(String.fromCharCode(...new Uint8Array(event.message)));
   let licenseResponse = await fetch(licenseServerUrl, {
     method: 'POST',
-    headers: new Headers({'Content-type': 'application/json', 'X-AxDRM-Message': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ2ZXJzaW9uIjoyLCJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImxpY2Vuc2UiOnsiYWxsb3dfcGVyc2lzdGVuY2UiOnRydWV9LCJjb250ZW50X2tleXNfc291cmNlIjp7ImlubGluZSI6W3siaWQiOiIyMTFhYzFkYy1jOGEyLTQ1NzUtYmFmNy1mYTRiYTU2YzM4YWMiLCJ1c2FnZV9wb2xpY3kiOiJUaGVPbmVQb2xpY3kifV19LCJjb250ZW50X2tleV91c2FnZV9wb2xpY2llcyI6W3sibmFtZSI6IlRoZU9uZVBvbGljeSIsInBsYXlyZWFkeSI6eyJwbGF5X2VuYWJsZXJzIjpbIjc4NjYyN0Q4LUMyQTYtNDRCRS04Rjg4LTA4QUUyNTVCMDFBNyJdfX1dfX0.D9FM9sbTFxBmcCOC8yMHrEtTwm0zy6ejZUCrlJbHz_U'}),
+    headers: new Headers({'Content-type': 'application/octet-stream'}),
     body: event.message,
-    // body: JSON.stringify({
-    //   "spc" : spc_string
-    // }),
   });
   return licenseResponse.arrayBuffer();
 }

--- a/src/helpers/drm.ts
+++ b/src/helpers/drm.ts
@@ -1,4 +1,4 @@
-import { MuxParams, DRMSystemConfiguration } from "../types";
+import { DRMSystemConfiguration } from "../types";
 
 export const initFairPlayDRM = async (element: HTMLElement, fairPlayOptions: DRMSystemConfiguration) => {
   const certificateUrl = fairPlayOptions.certificateUrl;
@@ -14,11 +14,11 @@ const loadFairPlayCertificate = async (certificateUrl: string) => {
   return response.arrayBuffer();
 }
 
-const fairplayEncryptedCallback = (fairPlayCertificate, licenseServerUrl) => {
-  return async (event) => {
+const fairplayEncryptedCallback = (fairPlayCertificate: ArrayBuffer, licenseServerUrl: string) => {
+  return async (event: MediaEncryptedEvent) => {
     console.log("fairplayEncrypted callback", event);
 
-    const video = event.target;
+    const video = event.target as HTMLVideoElement;
     const initDataType = event.initDataType;
 
     if (!video.mediaKeys) {
@@ -38,7 +38,7 @@ const fairplayEncryptedCallback = (fairPlayCertificate, licenseServerUrl) => {
 
     let session = video.mediaKeys.createSession();
     session.generateRequest(initDataType, initData);
-    let message = await new Promise(resolve => {
+    let message = await new Promise<MediaKeySessionEventMap["message"]>(resolve => {
       session.addEventListener('message', resolve, { once: true });
     });
 
@@ -48,8 +48,8 @@ const fairplayEncryptedCallback = (fairPlayCertificate, licenseServerUrl) => {
   }
 }
 
-const getLicenseResponse = async (event, licenseServerUrl) => {
-  let spc_string = btoa(String.fromCharCode(...new Uint8Array(event.message)));
+const getLicenseResponse = async (event: MediaKeySessionEventMap["message"], licenseServerUrl: string) => {
+  // let spc_string = btoa(String.fromCharCode(...new Uint8Array(event.message)));
   let licenseResponse = await fetch(licenseServerUrl, {
     method: 'POST',
     headers: new Headers({'Content-type': 'application/json', 'X-AxDRM-Message': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ2ZXJzaW9uIjoyLCJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImxpY2Vuc2UiOnsiYWxsb3dfcGVyc2lzdGVuY2UiOnRydWV9LCJjb250ZW50X2tleXNfc291cmNlIjp7ImlubGluZSI6W3siaWQiOiIyMTFhYzFkYy1jOGEyLTQ1NzUtYmFmNy1mYTRiYTU2YzM4YWMiLCJ1c2FnZV9wb2xpY3kiOiJUaGVPbmVQb2xpY3kifV19LCJjb250ZW50X2tleV91c2FnZV9wb2xpY2llcyI6W3sibmFtZSI6IlRoZU9uZVBvbGljeSIsInBsYXlyZWFkeSI6eyJwbGF5X2VuYWJsZXJzIjpbIjc4NjYyN0Q4LUMyQTYtNDRCRS04Rjg4LTA4QUUyNTVCMDFBNyJdfX1dfX0.D9FM9sbTFxBmcCOC8yMHrEtTwm0zy6ejZUCrlJbHz_U'}),

--- a/src/helpers/drm.ts
+++ b/src/helpers/drm.ts
@@ -1,0 +1,63 @@
+import { MuxParams, DRMSystemConfiguration } from "../types";
+
+export const initFairPlayDRM = async (element: HTMLElement, fairPlayOptions: DRMSystemConfiguration) => {
+  const certificateUrl = fairPlayOptions.certificateUrl;
+  const licenseServerUrl = fairPlayOptions.licenseUrl;
+
+  const fairPlayCertificate = await loadFairPlayCertificate(certificateUrl);
+
+  element.addEventListener('encrypted', fairplayEncryptedCallback(fairPlayCertificate, licenseServerUrl));
+};
+
+const loadFairPlayCertificate = async (certificateUrl: string) => {
+  let response = await fetch(certificateUrl);
+  return response.arrayBuffer();
+}
+
+const fairplayEncryptedCallback = (fairPlayCertificate, licenseServerUrl) => {
+  return async (event) => {
+    console.log("fairplayEncrypted callback", event);
+
+    const video = event.target;
+    const initDataType = event.initDataType;
+
+    if (!video.mediaKeys) {
+      let access = await navigator.requestMediaKeySystemAccess("com.apple.fps", [{
+        initDataTypes: [initDataType],
+        videoCapabilities: [{ contentType: 'application/vnd.apple.mpegurl' }],
+      }]);
+
+      console.log(access);
+      let keys = await access.createMediaKeys();
+
+      await keys.setServerCertificate(fairPlayCertificate);
+      await video.setMediaKeys(keys);
+    }
+
+    let initData = event.initData;
+
+    let session = video.mediaKeys.createSession();
+    session.generateRequest(initDataType, initData);
+    let message = await new Promise(resolve => {
+      session.addEventListener('message', resolve, { once: true });
+    });
+
+    let response = await getLicenseResponse(message, licenseServerUrl);
+    await session.update(response);
+    return session;
+  }
+}
+
+const getLicenseResponse = async (event, licenseServerUrl) => {
+  let spc_string = btoa(String.fromCharCode(...new Uint8Array(event.message)));
+  let licenseResponse = await fetch(licenseServerUrl, {
+    method: 'POST',
+    headers: new Headers({'Content-type': 'application/json', 'X-AxDRM-Message': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ2ZXJzaW9uIjoyLCJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImxpY2Vuc2UiOnsiYWxsb3dfcGVyc2lzdGVuY2UiOnRydWV9LCJjb250ZW50X2tleXNfc291cmNlIjp7ImlubGluZSI6W3siaWQiOiIyMTFhYzFkYy1jOGEyLTQ1NzUtYmFmNy1mYTRiYTU2YzM4YWMiLCJ1c2FnZV9wb2xpY3kiOiJUaGVPbmVQb2xpY3kifV19LCJjb250ZW50X2tleV91c2FnZV9wb2xpY2llcyI6W3sibmFtZSI6IlRoZU9uZVBvbGljeSIsInBsYXlyZWFkeSI6eyJwbGF5X2VuYWJsZXJzIjpbIjc4NjYyN0Q4LUMyQTYtNDRCRS04Rjg4LTA4QUUyNTVCMDFBNyJdfX1dfX0.D9FM9sbTFxBmcCOC8yMHrEtTwm0zy6ejZUCrlJbHz_U'}),
+    body: event.message,
+    // body: JSON.stringify({
+    //   "spc" : spc_string
+    // }),
+  });
+  return licenseResponse.arrayBuffer();
+}
+

--- a/src/helpers/drm.ts
+++ b/src/helpers/drm.ts
@@ -1,12 +1,12 @@
 import { DRMSystemConfiguration } from "../types";
 
-export const initFairPlayDRM = async (element: HTMLElement, fairPlayOptions: DRMSystemConfiguration) => {
+export const initFairPlayDRM = async (videoElement: HTMLVideoElement, fairPlayOptions: DRMSystemConfiguration) => {
   const certificateUrl = fairPlayOptions.certificateUrl;
   const licenseServerUrl = fairPlayOptions.licenseUrl;
 
   const fairPlayCertificate = await loadFairPlayCertificate(certificateUrl);
 
-  element.addEventListener('encrypted', fairplayEncryptedCallback(fairPlayCertificate, licenseServerUrl));
+  videoElement.addEventListener('encrypted', fairplayEncryptedCallback(fairPlayCertificate, licenseServerUrl));
 };
 
 const loadFairPlayCertificate = async (certificateUrl: string) => {
@@ -25,7 +25,6 @@ const fairplayEncryptedCallback = (fairPlayCertificate: ArrayBuffer, licenseServ
         videoCapabilities: [{ contentType: 'application/vnd.apple.mpegurl' }],
       }]);
 
-      console.log(access);
       let keys = await access.createMediaKeys();
 
       await keys.setServerCertificate(fairPlayCertificate);

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export enum Action {
   setMuxParams = "setMuxParams",
   setVideoOffset = "setVideoOffset",
   live = "live",
+  setDRMOptions = "setDRMOptions",
 }
 
 export enum Event {
@@ -138,6 +139,7 @@ export type State = Partial<
     muxData: MuxParams;
     live: boolean;
     initialized: boolean;
+    drmOptions?: DRMOptions;
   } & typeof device
 >;
 
@@ -165,3 +167,21 @@ export type MuxOptions = {
   Hls?: (typeof import("hls.js"))["default"];
   hlsjs?: Hls;
 };
+
+
+export const enum KeySystems {
+  clearkey = 'org.w3.clearkey',
+  fps = 'com.apple.fps',
+  playready = 'com.microsoft.playready',
+  widevine = 'com.widevine.alpha',
+};
+
+
+export type DRMSystemConfiguration = {
+  licenseUrl: string;
+  certificateUrl?: string;
+};
+
+export type DRMOptions = Partial<
+  Record<KeySystems, DRMSystemConfiguration>
+>;


### PR DESCRIPTION
## Short description
Basic DRM support

## Technical description
This PR adds basic DRM support to video-player. 

There are two ways to implement DRM:
1. Using HLS.js built-in support, which provides multiple key systems support
2. Using native html5 FairPlay support for apple webkit browsers

This should be enough for now, as hls is supported natively on Apple / Safari only. All others are using hls.js fallback. No additional formats are supported now

Basic DRM playback documentation could be find [here](https://docs.mux.com/guides/protect-videos-with-drm#play-drm-protected-videos)