### PR TITLE
[WHL-76] feat: prioritize browser language instead of storefront language to order list of subtitles

### DIFF
--- a/src/components/video-container/subtitles.ts
+++ b/src/components/video-container/subtitles.ts
@@ -35,8 +35,8 @@ const videoTextTtracksManager = (video: HTMLVideoElement, hls: Hls) => {
   };
 
   const tracksToStoreState = () => {
-    const pageLanguage = document.documentElement.lang;
-    const pageLanguageCode = pageLanguage.split('-')?.[0];
+    const userLanguage = navigator.language;
+    const userLanguageCode = userLanguage.split('-')[0];
 
     return {
       textTracks: getTracks().map((t) => ({
@@ -45,9 +45,9 @@ const videoTextTtracksManager = (video: HTMLVideoElement, hls: Hls) => {
         label: t.label,
         id: buildTrackId(t),
       })).sort((a, b) => {
-        if (pageLanguageCode) {
-          const aMatches = a.lang === pageLanguageCode;
-          const bMatches = b.lang === pageLanguageCode;
+        if (userLanguageCode) {
+          const aMatches = a.lang === userLanguageCode;
+          const bMatches = b.lang === userLanguageCode;
           if (aMatches && !bMatches) return -1;
           if (!aMatches && bMatches) return 1;
         }

--- a/src/components/video-container/subtitles.ts
+++ b/src/components/video-container/subtitles.ts
@@ -35,7 +35,7 @@ const videoTextTtracksManager = (video: HTMLVideoElement, hls: Hls) => {
   };
 
   const tracksToStoreState = () => {
-    const userLanguage = navigator.language;
+    const userLanguage = navigator.language || document.documentElement.lang || 'en';
     const userLanguageCode = userLanguage.split('-')[0];
 
     return {


### PR DESCRIPTION
Part of WHL-76

Use `navigator.language` instead of getting the HTML document's language in order to display the user's language first in the list of subtitles (if available), and then keep sorting subtitle languages alphabetically based on the label (so, the English name of the language) instead of what we originally did, which was by subtitle language ISO code.

Can it be undefined? According to Gemini:
> In short: No, navigator.language should never be undefined, null, or an empty string.
>
> According to the HTML and ECMAScript internationalization specifications, this property is designed to always return a string representing the user's preferred language (usually the UI language of the browser or the OS).
> The navigator.language property is part of the Language Preferences API. Per the W3C and WHATWG standards:
>
>  - It must return a string.
>  - The string should be a valid BCP 47 language tag (e.g., "en-US", "es", "fr-FR").
>  - If the browser cannot determine the language, it is expected to return a default (often "en-US" or "en").
