### PR TITLE
fix: accessibility issues in player controls (CAT-1578)

### DIFF
--- a/src/components/video-button/Video-button.component.ts
+++ b/src/components/video-button/Video-button.component.ts
@@ -170,7 +170,13 @@ export class VideoButton extends LitElement {
       ${when(
         !isMobile(),
         () => html`
-          <div id="tooltip" role="tooltip" class="tooltip" part="tooltip">
+          <div
+            id="tooltip"
+            role="tooltip"
+            tabindex="0"
+            class="tooltip"
+            part="tooltip"
+          >
             <div class="inner">${tooltip}</div>
           </div>
         `,

--- a/src/components/video-button/Video-button.styles.css
+++ b/src/components/video-button/Video-button.styles.css
@@ -95,3 +95,9 @@ button {
 .menu .inner {
   padding: 0;
 }
+
+.tooltip:focus-visible,
+.menu:focus-visible {
+  outline: 2px solid var(--primary, var(--tooltip-text, #fff));
+  outline-offset: 2px;
+}

--- a/src/components/video-slider/Video-slider.component.ts
+++ b/src/components/video-slider/Video-slider.component.ts
@@ -10,6 +10,7 @@ import {
 } from "@popperjs/core";
 import { closestElement } from "../../helpers/closest";
 import { when } from "lit/directives/when.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { isDeepAssigned } from "../../helpers/slot";
 
 type CombinedEventType = PointerEvent &
@@ -59,6 +60,13 @@ export class VideoSlider extends LitElement {
    */
   @property({ attribute: "value-text" })
   valueText = "";
+
+  /**
+   * Accessible name for the slider, exposed as `aria-label` on the range input.
+   * Screen readers announce this so the control has a name (WCAG 1.3.1, 4.1.2).
+   */
+  @property({ attribute: "label" })
+  label = "";
 
   /**
    * Text to display in the tooltip.
@@ -247,6 +255,7 @@ export class VideoSlider extends LitElement {
           max="100"
           step="0.001"
           role="slider"
+          aria-label=${ifDefined(this.label || undefined)}
           ?disabled=${this.disabled}
           .value=${this.positionInPercents}
           .aria-valuenow=${this.currentValue}

--- a/src/components/video-timeline/Video-timeline.component.ts
+++ b/src/components/video-timeline/Video-timeline.component.ts
@@ -140,6 +140,7 @@ export class VideoTimeline extends DependentPropsMixin(LitElement) {
     return html`
       <video-slider
         with-tooltip
+        label="Seek"
         .value=${this.currentValue}
         .max=${this.duration}
         .valueText="${timeAsString(this.currentValue)} of ${timeAsString(

--- a/src/components/video-volume-control/Video-volume-control.component.ts
+++ b/src/components/video-volume-control/Video-volume-control.component.ts
@@ -29,6 +29,7 @@ export class VideoVolumeControl extends LitElement {
     if (this.isIos) return null;
     return html`
       <video-slider
+        label="Volume"
         .value=${this.isMuted ? 0 : this.volume}
         @changed=${this.handleVolumeChange}
       ></video-slider>


### PR DESCRIPTION
## What

Fixes accessibility issues in the player controls (CAT-1578).

- **`video-slider`**: new `label` property, exposed as `aria-label` on the range input so screen readers announce the control (WCAG 1.3.1, 4.1.2).
- **`video-timeline`**: passes `label="Seek"`.
- **`video-volume-control`**: passes `label="Volume"`.
- **`video-button`**: tooltip gets `tabindex="0"` and a `:focus-visible` outline for keyboard users.

## Testing

- `pnpm run build` passes cleanly (dist/lib/types).
- Verified locally by packing (`npm pack`) and installing into a consuming project: sliders now expose accessible names ("Seek"/"Volume") in the DevTools Accessibility pane.

## Notes for reviewers

Two details worth a look:
1. Tooltip `tabindex="0"` adds a keyboard tab stop on the tooltip element itself — the ARIA tooltip pattern usually keeps tooltips out of the tab order. Confirm this matches the intended behavior.
2. The `.menu:focus-visible` half of the new CSS rule is currently unreachable (`.menu` has no `tabindex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)